### PR TITLE
Notarize our own page with simple_prover

### DIFF
--- a/tlsn/examples/simple/simple_verifier.rs
+++ b/tlsn/examples/simple/simple_verifier.rs
@@ -8,8 +8,14 @@ use tlsn_core::proof::{SessionProof, TlsProof};
 /// it and prints the verified data to the console.
 fn main() {
     // Deserialize the proof
-    let proof = std::fs::read_to_string("simple_proof.json").unwrap();
-    let proof: TlsProof = serde_json::from_str(proof.as_str()).unwrap();
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 2 {
+        eprintln!("Usage: {} <proof_file>", args[0]);
+        std::process::exit(1);
+    }
+    let proof_file = &args[1];
+    let proof = std::fs::read_to_string(proof_file).unwrap();
+    let proof: TlsProof = serde_json::from_str(&proof).unwrap();
 
     let TlsProof {
         // The session proof establishes the identity of the server and the commitments


### PR DESCRIPTION
- Notarize page for [party 0](https://mhchia.github.io/followers-page/party_0.html), [party 1](https://mhchia.github.io/followers-page/party_1.html), [party 2](https://mhchia.github.io/followers-page/party_2.html), and print the followers out for later usage.
- Changes to make it easier to run for our run script
    - simple_prover: run with
	- `cargo run --release --example simple_prover {party_index} {path_to_save_proof}`
    - simple_verifier: run with
	- `cargo run --release --example simple_verifier {proof_path}`